### PR TITLE
Filter the actual embed URL of HubSpot widgets

### DIFF
--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -33,7 +33,7 @@ chrome.webRequest.onBeforeRequest.addListener(
                 "*://*.intergram.xyz/js/*",
                 "*://widget.mfy.im/*",
                 "*://connect.podium.com/*",
-                "*://app.hubspot.com/*",
+                "*://js.usemessages.com/*",
                 "*://static.getchipbot.com/",
                 "*://static.zdassets.com/ekr/snippet.js",
                 "*://www.couchbase.com/webfiles/1552355627964/js/contact-popup-form.js",

--- a/filterlist.txt
+++ b/filterlist.txt
@@ -15,7 +15,7 @@
 ||*.intergram.xyz/js/*
 ||widget.mfy.im/*
 ||connect.podium.com/*
-||app.hubspot.com/*
+||js.usemessages.com/*
 ||static.getchipbot.com/*
 ||static.zdassets.com/ekr/snippet.js^
 ||www.couchbase.com/webfiles/1552355627964/js/contact-popup-form.js


### PR DESCRIPTION
The filter currently blocks the entirety of HubSpot's app, but this update targets just the embeddable widget. I haven't updated the compressed archives `app.zip` and `firefox_app.zip` but they should probably receive some love as well (since those filter lists seem to be out of date)