### PR TITLE
Update Title in filterlist.txt to match titles of add-ons

### DIFF
--- a/filterlist.txt
+++ b/filterlist.txt
@@ -1,4 +1,4 @@
-! Title: Hello Goodbye Filter
+! Title: Hello, Goodbye!
 ! Expires: 5 days
 ! Homepage: https://hellogoodbye.app/
 ! Description: Blocks every chat or helpdesk pop up in your browser.


### PR DESCRIPTION
I made the punctuation match the website and the extension and add-on. And there is no need to include “Filter” in the name of the filter – this would be redundant when viewing the filter list in the uBlock Origin interface.