### PR TITLE
Fix comment syntax in filterlist.txt

### DIFF
--- a/filterlist.txt
+++ b/filterlist.txt
@@ -3,9 +3,9 @@
 ! Homepage: https://hellogoodbye.app/
 ! Description: Blocks every chat or helpdesk pop up in your browser.
 
-# =================
-# Stop Chat Pop Ups
-# =================
+! =================
+! Stop Chat Pop Ups
+! =================
 
 ||widget.intercom.io/*
 ||connect.facebook.net/en_US/sdk/xfbml.customerchat.js


### PR DESCRIPTION
According to https://adblockplus.org/en/filters#comments, in Adblock Plus filters, the only valid comment prefix is `!`, not `#`. I did a quick search through some other filter lists for a `#` comment syntax and they don’t use it either.