### PR TITLE
Add title to abp:subscribe url

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
                             <span> or </span>
 							<a class="button button-primary button-shadow" href="https://addons.mozilla.org/en-US/firefox/addon/hello-goodbye">Download for Firefox</a>
 							<span> or </span>
-							<a href="abp:subscribe?location=https://raw.githubusercontent.com/bcye/Hello-Goodbye/master/filterlist.txt" class="button button-primary button-shadow">Download Filterlist</a>
+							<a href="abp:subscribe?location=https://raw.githubusercontent.com/bcye/Hello-Goodbye/master/filterlist.txt&title=Hello-Goodbye" class="button button-primary button-shadow">Download Filterlist</a>
 						</div>
                         <div class="hero-browser">
                           <!--


### PR DESCRIPTION
Shows name in filter list and uB Origin was unable to handle the link without title on Firefox.