### PR TITLE
Update blocklists with giosg and cuuma

### DIFF
--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -109,6 +109,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       "*://lawbook.online/chat.js*",
       "*://static.parastorage.com/services/chat-widget/*",
       "*://service.giosg.com/*",
+      "*://chatbox.cuuma.fi/*",
 
       // someone from x just bought y widgets
       "*://static.notifia.io/widget.js",

--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -108,6 +108,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       "*://corp.aquadom.info/upload/crm/site_button/loader_1_lue57s.js*",
       "*://lawbook.online/chat.js*",
       "*://static.parastorage.com/services/chat-widget/*",
+      "*://service.giosg.com/*",
 
       // someone from x just bought y widgets
       "*://static.notifia.io/widget.js",

--- a/filterlist.txt
+++ b/filterlist.txt
@@ -101,3 +101,4 @@
 ||corp.aquadom.info/upload/crm/site_button/loader_1_lue57s.js*
 ||lawbook.online/chat.js*
 ||static.parastorage.com/services/chat-widget/*
+||service.giosg.com

--- a/filterlist.txt
+++ b/filterlist.txt
@@ -102,3 +102,4 @@
 ||lawbook.online/chat.js*
 ||static.parastorage.com/services/chat-widget/*
 ||service.giosg.com
+||chatbox.cuuma.fi

--- a/pihole.txt
+++ b/pihole.txt
@@ -76,3 +76,4 @@ crm.digtlab.ru
 me-talk.ru
 cdn-app.continual.ly
 service.giosg.com
+chatbox.cuuma.fi

--- a/pihole.txt
+++ b/pihole.txt
@@ -75,3 +75,4 @@ live.vnpgroup.net
 crm.digtlab.ru
 me-talk.ru
 cdn-app.continual.ly
+service.giosg.com


### PR DESCRIPTION
Block a few chat providers used by finnish sites.

Giosg block can be tested either at their own site at https://www.giosg.com/ or e.g. at https://www.vepsalainen.com .
Cuuma block can be tested at https://ksvv.fi/ .